### PR TITLE
[Hyeonwoo follow] [ init ] 팔로우 기능 기본 구현

### DIFF
--- a/src/main/java/com/sparta/dtogram/follow/controller/FollowController.java
+++ b/src/main/java/com/sparta/dtogram/follow/controller/FollowController.java
@@ -1,0 +1,34 @@
+package com.sparta.dtogram.follow.controller;
+
+import com.sparta.dtogram.common.security.UserDetailsImpl;
+import com.sparta.dtogram.follow.service.FollowService;
+import com.sparta.dtogram.post.dto.PostRequestDto;
+import com.sparta.dtogram.post.dto.PostResponseDto;
+import com.sparta.dtogram.post.service.PostService;
+import com.sparta.dtogram.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class FollowController {
+
+    private final FollowService followService;
+
+
+    @GetMapping("/follow")
+    public String follow(@RequestParam User followingUser, @AuthenticationPrincipal UserDetailsImpl followerUserDetails) {
+        return followService.doFollow(followingUser, followerUserDetails.getUser());
+    }
+
+    @GetMapping("/unfollow")
+    public String unFollow(@RequestParam User followingUser, @AuthenticationPrincipal UserDetailsImpl followerUserDetails) {
+        return followService.unFollow(followingUser, followerUserDetails.getUser());
+    }
+
+
+}

--- a/src/main/java/com/sparta/dtogram/follow/entity/Follow.java
+++ b/src/main/java/com/sparta/dtogram/follow/entity/Follow.java
@@ -1,0 +1,35 @@
+package com.sparta.dtogram.follow.entity;
+
+import com.sparta.dtogram.user.entity.User;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+
+@Entity // JPA가 관리할 수 있는 Entity 클래스 지정
+@Getter
+@Setter
+@Table(name = "follow") // 매핑할 테이블의 이름을 지정
+@NoArgsConstructor
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id", nullable = false)
+    private User followingUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id", nullable = false)
+    private User followerUser;
+
+
+    public Follow(User followingUser, User followerUser) {
+        this.followingUser = followingUser;
+        this.followerUser = followerUser;
+    }
+}
+

--- a/src/main/java/com/sparta/dtogram/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sparta/dtogram/follow/repository/FollowRepository.java
@@ -1,0 +1,13 @@
+package com.sparta.dtogram.follow.repository;
+
+import com.sparta.dtogram.follow.entity.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    List<Follow> findByFollowingUser_Id(Long id);
+    List<Follow> findByFollowerUser_Id(Long id);
+    Optional<Follow> findByFollowerUser_IdAndFollowingUser_Id(Long id, Long id1);
+}

--- a/src/main/java/com/sparta/dtogram/follow/service/FollowService.java
+++ b/src/main/java/com/sparta/dtogram/follow/service/FollowService.java
@@ -1,0 +1,71 @@
+package com.sparta.dtogram.follow.service;
+
+import com.sparta.dtogram.follow.entity.Follow;
+import com.sparta.dtogram.follow.repository.FollowRepository;
+import com.sparta.dtogram.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FollowService {
+
+    private final FollowRepository followRepository;
+
+
+    public String doFollow(User followingUser, User followerUser) {
+
+
+        //이미 팔로우가 되어있는지 검사.
+        Follow existFollow = followRepository.findByFollowerUser_IdAndFollowingUser_Id(followingUser.getId(), followerUser.getId())
+                .orElseThrow(() -> new IllegalArgumentException("팔로우 정보가 없습니다."));
+
+        if (existFollow == null) { // 위에서 Optional로 받아서 Null을 거르는 건데 이게 맞나.?
+
+            Follow newFollow = new Follow(followingUser, followerUser);
+            followRepository.save(newFollow);
+
+        }
+
+        return "팔로우 완료.";
+    }
+
+
+    public String unFollow(User followingUser, User followerUser) {
+
+        //이미 팔로우가 되어있는지 검사.
+        Follow existFollow = followRepository.findByFollowerUser_IdAndFollowingUser_Id(followingUser.getId(), followerUser.getId())
+                .orElseThrow(() -> new IllegalArgumentException("팔로우 정보가 없습니다."));
+
+        if (existFollow != null) { // 위에서 Optional로 받아서 Null을 거르는 건데 이게 맞나.?
+            followRepository.delete(existFollow);
+        }
+
+        return "언팔로우 완료.";
+    }
+
+
+    public List<User> getFollowerList(User user) {
+        List<Follow> followList = followRepository.findByFollowingUser_Id(user.getId());
+
+        List<User> followerList = new ArrayList<>();
+        for (Follow follow : followList) {
+            followerList.add(follow.getFollowerUser());
+        }
+        return followerList;
+    }
+
+    public List<User> getFollowingList(User user) {
+        List<Follow> followList = followRepository.findByFollowerUser_Id(user.getId()); // 내가 팔로워인 모든 관계의 합은 나의 팔로잉 숫자이다.
+
+        List<User> followingList = new ArrayList<>();
+        for (Follow follow : followList) {
+            followingList.add(follow.getFollowerUser());
+        }
+        return followingList;
+    }
+}
+


### PR DESCRIPTION
1. 팔로우 엔티티 생성
  : 유저와 유저를 잇는 중간테이블 역할

2. 팔로우 / 언팔로우 기능 생성
  : 현재 리턴값을 그냥 "팔로우 완료" 정도로 해둔 상태. 프론트에서 필요한 Response가 있는지 논의 필요.

  프론트상에서 팔로우와 언팔로우 버튼이 아예 다를거라고 생각하고 팔로우 언팔로우를 아예 분리. (doFollow, unFollow)


```

public String doFollow(User followingUser, User followerUser) {


        //이미 팔로우가 되어있는지 검사.
        Follow existFollow = followRepository.findByFollowerUser_IdAndFollowingUser_Id(followingUser.getId(), followerUser.getId())
                .orElseThrow(() -> new IllegalArgumentException("팔로우 정보가 없습니다."));

        if (existFollow == null) { // 위에서 Optional로 받아서 Null을 거르는 건데 이게 맞나.?

            Follow newFollow = new Follow(followingUser, followerUser);
            followRepository.save(newFollow);

        }

        return "팔로우 완료.";
    }
```

3. 팔로잉, 팔로워 리스트를 리턴하는 메소드 생성.
  : List<User> followingList  이런식으로 User List를 리턴하는 식으로 생성해둠. 
   이후 개인 페이지를 구현한다거나 리스트 혹은 팔로잉 숫자가 필요할때 followingList(this).size(); 식으로 리턴해서 쓸 수 있어 보임.
```
 public List<User> getFollowerList(User user) {
        List<Follow> followList = followRepository.findByFollowingUser_Id(user.getId());

        List<User> followerList = new ArrayList<>();
        for (Follow follow : followList) {
            followerList.add(follow.getFollowerUser());
        }
        return followerList;
    }
```

