### PR TITLE
[Hyeonwoo follow] [ fix ] API에 맞게 수정

### DIFF
--- a/src/main/java/com/sparta/dtogram/follow/controller/FollowController.java
+++ b/src/main/java/com/sparta/dtogram/follow/controller/FollowController.java
@@ -20,14 +20,14 @@ public class FollowController {
     private final FollowService followService;
 
 
-    @GetMapping("/follow")
-    public String follow(@RequestParam User followingUser, @AuthenticationPrincipal UserDetailsImpl followerUserDetails) {
-        return followService.doFollow(followingUser, followerUserDetails.getUser());
+    @PostMapping("/follow")
+    public String follow(@AuthenticationPrincipal UserDetailsImpl followingUserDetails, @RequestParam Long followerId) {
+        return followService.doFollow(followingUserDetails.getUser(),followerId);
     }
 
-    @GetMapping("/unfollow")
-    public String unFollow(@RequestParam User followingUser, @AuthenticationPrincipal UserDetailsImpl followerUserDetails) {
-        return followService.unFollow(followingUser, followerUserDetails.getUser());
+    @PostMapping("/unfollow")
+    public String unFollow(@AuthenticationPrincipal UserDetailsImpl followingUserDetails, @RequestParam Long followerId) {
+        return followService.unFollow(followingUserDetails.getUser(),followerId);
     }
 
 

--- a/src/main/java/com/sparta/dtogram/follow/repository/FollowRepository.java
+++ b/src/main/java/com/sparta/dtogram/follow/repository/FollowRepository.java
@@ -1,13 +1,17 @@
 package com.sparta.dtogram.follow.repository;
 
 import com.sparta.dtogram.follow.entity.Follow;
+import com.sparta.dtogram.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface FollowRepository extends JpaRepository<Follow, Long> {
+    boolean existsByFollowingUserAndFollowerUser_Id(User followingUser, Long id);
     List<Follow> findByFollowingUser_Id(Long id);
     List<Follow> findByFollowerUser_Id(Long id);
-    Optional<Follow> findByFollowerUser_IdAndFollowingUser_Id(Long id, Long id1);
+
+    Optional<Follow> findByFollowingUserAndFollowerUser(User followingUser, User followerUser);
+    Boolean existsByFollowingUserAndFollowerUser(User followingUser, User followerUser);
 }


### PR DESCRIPTION
*Controller
1. GET -> POST 메소드 방식으로 수정
2. 매개변수 순서 변경 (UserDetails.getUser(), 팔로워 id)
3. 리턴값 상태코드&메시지 형태의 String으로 수정. 

*Service
1. 가급적 팔로잉 -> 팔로워 식의 방향성에 맞게 매개변수값의 순서를 정리함.
  팔로우를 하는 사람은 팔로잉유저 followingUser.
  팔로우를 받는 사람은 팔로워유저 followerUser.

2. getUserById 메소드를 내부에 private으로 따로 정리.