### PR TITLE
[Hyeonwoo admin] 관리자 기본 유저 조회 수정 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sparta/dtogram/admin/controller/AdminController.java
+++ b/src/main/java/com/sparta/dtogram/admin/controller/AdminController.java
@@ -1,0 +1,33 @@
+package com.sparta.dtogram.admin.controller;
+
+import com.sparta.dtogram.admin.service.AdminService;
+import com.sparta.dtogram.common.dto.ApiResponseDto;
+import com.sparta.dtogram.common.security.UserDetailsImpl;
+import com.sparta.dtogram.user.dto.ProfileRequestDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class AdminController {
+    private final AdminService adminService;
+
+    @PutMapping("/admin/user/{id}")
+    public ResponseEntity<ApiResponseDto> editUser(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                     @PathVariable Long id,
+                                                     @RequestBody ProfileRequestDto requestDto){
+        try {
+            adminService.editProfileByAdmin(userDetails.getUser(), id, requestDto);
+            return ResponseEntity.ok().body(new ApiResponseDto("프로필 수정 성공", HttpStatus.OK.value()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ApiResponseDto(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
+        }
+    }
+
+}

--- a/src/main/java/com/sparta/dtogram/admin/controller/AdminController.java
+++ b/src/main/java/com/sparta/dtogram/admin/controller/AdminController.java
@@ -30,6 +30,20 @@ public class AdminController {
         }
     }
 
+    @PutMapping("/admin/user/{id}/{role}")
+    public ResponseEntity<ApiResponseDto> editUser(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                   @PathVariable Long id,
+                                                   @PathVariable String role){
+        try {
+            adminService.editRoleByAdmin(userDetails.getUser(), id, role);
+            return ResponseEntity.ok().body(new ApiResponseDto("유저 정보 수정 성공", HttpStatus.OK.value()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ApiResponseDto(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
+        }
+    }
+
+
+
     @DeleteMapping("/admin/user/{id}")
     public ResponseEntity<ApiResponseDto> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                    @PathVariable Long id){

--- a/src/main/java/com/sparta/dtogram/admin/controller/AdminController.java
+++ b/src/main/java/com/sparta/dtogram/admin/controller/AdminController.java
@@ -24,7 +24,18 @@ public class AdminController {
                                                      @RequestBody ProfileRequestDto requestDto){
         try {
             adminService.editProfileByAdmin(userDetails.getUser(), id, requestDto);
-            return ResponseEntity.ok().body(new ApiResponseDto("프로필 수정 성공", HttpStatus.OK.value()));
+            return ResponseEntity.ok().body(new ApiResponseDto("유저 정보 수정 성공", HttpStatus.OK.value()));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(new ApiResponseDto(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
+        }
+    }
+
+    @DeleteMapping("/admin/user/{id}")
+    public ResponseEntity<ApiResponseDto> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                   @PathVariable Long id){
+        try {
+            adminService.deleteUserByAdmin(userDetails.getUser(), id);
+            return ResponseEntity.ok().body(new ApiResponseDto("유저 삭제 완료", HttpStatus.OK.value()));
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest().body(new ApiResponseDto(e.getMessage(), HttpStatus.BAD_REQUEST.value()));
         }

--- a/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
+++ b/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
@@ -6,6 +6,7 @@ import com.sparta.dtogram.user.entity.UserRoleEnum;
 import com.sparta.dtogram.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -13,11 +14,19 @@ public class AdminService {
 
     private final UserRepository userRepository;
 
-
+    @Transactional
     public void editProfileByAdmin(User userAdmin, Long targetId, ProfileRequestDto requestDto) {
         checkAdminRole(userAdmin);
         findUser(targetId)
                 .updateProfile(requestDto); //todo 기존 profile업데이트 기능을 계속 써도 될지?
+    }
+
+    @Transactional
+    public void editRoleByAdmin(User userAdmin, Long targetId, UserRoleEnum role) {
+        checkAdminRole(userAdmin);
+        findUser(targetId)
+                .updateRole(role);
+
     }
 
     public void deleteUserByAdmin(User userAdmin, Long targetId) {
@@ -25,12 +34,7 @@ public class AdminService {
         userRepository.delete(findUser(targetId));
     }
 
-    public void editRoleByAdmin(User userAdmin, Long targetId, UserRoleEnum role){
-        checkAdminRole(userAdmin);
-        findUser(targetId)
-                .updateRole(role);
 
-    }
 
 
 
@@ -40,7 +44,7 @@ public class AdminService {
         }
     }
 
-    private User findUser(Long targetId){
+    private User findUser(Long targetId) {
         User targetUser = userRepository.findById(targetId).orElseThrow(() ->
                 new IllegalArgumentException("해당 유저의 정보를 찾을 수 없습니다.")
         );

--- a/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
+++ b/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
@@ -1,0 +1,29 @@
+package com.sparta.dtogram.admin.service;
+
+import com.sparta.dtogram.user.dto.ProfileRequestDto;
+import com.sparta.dtogram.user.entity.User;
+import com.sparta.dtogram.user.entity.UserRoleEnum;
+import com.sparta.dtogram.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final UserRepository userRepository;
+
+
+    public void editProfileByAdmin(User userAdmin, Long targetId, ProfileRequestDto requestDto) {
+        if(userAdmin.getRole()!= UserRoleEnum.ADMIN){
+            throw new IllegalArgumentException("Admin 권한이 없습니다.");
+        }
+
+        User targetUser = userRepository.findById(targetId).orElseThrow(()->
+                new IllegalArgumentException("해당 유저의 정보를 찾을 수 없습니다.")
+                );
+
+        targetUser.updateProfile(requestDto); //todo 기존 profile업데이트 기능을 계속 써도 될지?
+    }
+
+}

--- a/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
+++ b/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
@@ -15,15 +15,28 @@ public class AdminService {
 
 
     public void editProfileByAdmin(User userAdmin, Long targetId, ProfileRequestDto requestDto) {
-        if(userAdmin.getRole()!= UserRoleEnum.ADMIN){
-            throw new IllegalArgumentException("Admin 권한이 없습니다.");
-        }
-
-        User targetUser = userRepository.findById(targetId).orElseThrow(()->
-                new IllegalArgumentException("해당 유저의 정보를 찾을 수 없습니다.")
-                );
-
-        targetUser.updateProfile(requestDto); //todo 기존 profile업데이트 기능을 계속 써도 될지?
+        checkAdminRole(userAdmin);
+        findUser(targetId)
+                .updateProfile(requestDto); //todo 기존 profile업데이트 기능을 계속 써도 될지?
     }
 
+    public void deleteUserByAdmin(User userAdmin, Long targetId) {
+        checkAdminRole(userAdmin);
+        userRepository.delete(findUser(targetId));
+    }
+
+
+
+    private void checkAdminRole(User userAdmin) {
+        if (userAdmin.getRole() != UserRoleEnum.ADMIN) {
+            throw new IllegalArgumentException("Admin 권한이 없습니다.");
+        }
+    }
+
+    private User findUser(Long targetId){
+        User targetUser = userRepository.findById(targetId).orElseThrow(() ->
+                new IllegalArgumentException("해당 유저의 정보를 찾을 수 없습니다.")
+        );
+        return targetUser;
+    }
 }

--- a/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
+++ b/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
@@ -25,6 +25,13 @@ public class AdminService {
         userRepository.delete(findUser(targetId));
     }
 
+    public void editRoleByAdmin(User userAdmin, Long targetId, UserRoleEnum role){
+        checkAdminRole(userAdmin);
+        findUser(targetId)
+                .updateRole(role);
+
+    }
+
 
 
     private void checkAdminRole(User userAdmin) {

--- a/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
+++ b/src/main/java/com/sparta/dtogram/admin/service/AdminService.java
@@ -22,10 +22,13 @@ public class AdminService {
     }
 
     @Transactional
-    public void editRoleByAdmin(User userAdmin, Long targetId, UserRoleEnum role) {
+    public void editRoleByAdmin(User userAdmin, Long targetId, String role) {
         checkAdminRole(userAdmin);
+
+        UserRoleEnum newRole = UserRoleEnum.valueOf(role);
+
         findUser(targetId)
-                .updateRole(role);
+                .updateRole(newRole);
 
     }
 

--- a/src/main/java/com/sparta/dtogram/user/controller/UserController.java
+++ b/src/main/java/com/sparta/dtogram/user/controller/UserController.java
@@ -4,6 +4,7 @@ package com.sparta.dtogram.user.controller;
 import com.sparta.dtogram.common.security.UserDetailsImpl;
 import com.sparta.dtogram.user.dto.SignupRequestDto;
 import com.sparta.dtogram.user.dto.UserInfoDto;
+import com.sparta.dtogram.user.entity.User;
 import com.sparta.dtogram.user.entity.UserRoleEnum;
 import com.sparta.dtogram.user.service.UserService;
 import jakarta.validation.Valid;
@@ -54,4 +55,22 @@ public class UserController {
 
         return ResponseEntity.ok().body("회원 가입 성공");
     }
+
+
+    @GetMapping("/user/{id}")
+    public ResponseEntity<User> getUser(@PathVariable Long id){
+        return ResponseEntity.ok().body(userService.getUser(id));
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<List<User>> getAllUsers(){
+        return ResponseEntity.ok().body(userService.getAllUsers());
+    }
+
+    @GetMapping("/user/{nickname}") //오버로딩
+    public ResponseEntity<List<User>> getAllUsers(@PathVariable String nickname){
+        return ResponseEntity.ok().body(userService.getAllUsers(nickname));
+    }
+
+
 }

--- a/src/main/java/com/sparta/dtogram/user/controller/UserController.java
+++ b/src/main/java/com/sparta/dtogram/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.sparta.dtogram.user.controller;
 
 
+import com.sparta.dtogram.user.dto.ProfileResponseDto;
 import com.sparta.dtogram.user.dto.SignupRequestDto;
 import com.sparta.dtogram.user.entity.User;
 import com.sparta.dtogram.user.service.UserService;
@@ -54,17 +55,17 @@ public class UserController {
 
 
     @GetMapping("/user/{id}")
-    public ResponseEntity<User> getUser(@PathVariable Long id){
-        return ResponseEntity.ok().body(userService.getUser(id));
+    public ResponseEntity<ProfileResponseDto> getUser(@PathVariable Long id){
+        return ResponseEntity.ok().body(new ProfileResponseDto(userService.getUser(id)));
     }
 
-    @GetMapping("/user")
-    public ResponseEntity<List<User>> getAllUsers(){
+    @GetMapping("/users")
+    public ResponseEntity<List<ProfileResponseDto>> getAllUsers(){
         return ResponseEntity.ok().body(userService.getAllUsers());
     }
 
-    @GetMapping("/user/{nickname}") //오버로딩
-    public ResponseEntity<List<User>> getAllUsers(@PathVariable String nickname){
+    @GetMapping("/users/{nickname}") //오버로딩
+    public ResponseEntity<List<ProfileResponseDto>> getAllUsers(@PathVariable String nickname){
         return ResponseEntity.ok().body(userService.getAllUsers(nickname));
     }
 

--- a/src/main/java/com/sparta/dtogram/user/controller/UserController.java
+++ b/src/main/java/com/sparta/dtogram/user/controller/UserController.java
@@ -1,16 +1,12 @@
 package com.sparta.dtogram.user.controller;
 
 
-import com.sparta.dtogram.common.security.UserDetailsImpl;
 import com.sparta.dtogram.user.dto.SignupRequestDto;
-import com.sparta.dtogram.user.dto.UserInfoDto;
 import com.sparta.dtogram.user.entity.User;
-import com.sparta.dtogram.user.entity.UserRoleEnum;
 import com.sparta.dtogram.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;

--- a/src/main/java/com/sparta/dtogram/user/entity/PasswordHistory.java
+++ b/src/main/java/com/sparta/dtogram/user/entity/PasswordHistory.java
@@ -1,7 +1,6 @@
 package com.sparta.dtogram.user.entity;
 
 import com.sparta.dtogram.common.entity.Timestamped;
-import com.sparta.dtogram.user.repository.PasswordHistoryRepository;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/com/sparta/dtogram/user/entity/User.java
+++ b/src/main/java/com/sparta/dtogram/user/entity/User.java
@@ -95,4 +95,8 @@ public class User {
         this.naverId = naverId;
         return this;
     }
+
+    public void updateRole(UserRoleEnum role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/sparta/dtogram/user/entity/User.java
+++ b/src/main/java/com/sparta/dtogram/user/entity/User.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,12 +65,12 @@ public class User {
 
     //todo 추후 다른 소셜 로그인과 섞일 염려가 있음
     public User(String username, String password, String email, UserRoleEnum role, Long kakaoId) {
-        this.username = "kakao"+username;
+        this.username = "kakao" + username;
         this.nickname = username;
         this.password = password;
         this.email = email;
         this.role = role;
-        this.kakaoId =kakaoId;
+        this.kakaoId = kakaoId;
     }
 
     public User(String username, String nickname, String password, String email, UserRoleEnum role, String naverId) {
@@ -78,12 +79,12 @@ public class User {
         this.password = password;
         this.email = email;
         this.role = role;
-        this.naverId =naverId;
+        this.naverId = naverId;
     }
 
     public void updateProfile(ProfileRequestDto requestDto) {
-        this.nickname = requestDto.getNickname();
-        this.introduction = requestDto.getIntroduction();
+        this.nickname = requestDto.getNickname()==null ? this.nickname : requestDto.getNickname();
+        this.introduction = requestDto.getIntroduction()==null ? this.introduction : requestDto.getIntroduction();
     }
 
     public User kakaoIdUpdate(Long kakaoId) {

--- a/src/main/java/com/sparta/dtogram/user/entity/UserRoleEnum.java
+++ b/src/main/java/com/sparta/dtogram/user/entity/UserRoleEnum.java
@@ -2,6 +2,7 @@ package com.sparta.dtogram.user.entity;
 
 public enum UserRoleEnum {
     USER(Authority.USER),  // 사용자 권한
+    MANAGER(Authority.MANAGER), // 운영자 권한
     ADMIN(Authority.ADMIN);  // 관리자 권한
 
     private final String authority;
@@ -16,6 +17,7 @@ public enum UserRoleEnum {
 
     public static class Authority {
         public static final String USER = "ROLE_USER";
+        public static final String MANAGER = "ROLE_MANAGER";
         public static final String ADMIN = "ROLE_ADMIN";
     }
 }

--- a/src/main/java/com/sparta/dtogram/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/dtogram/user/repository/UserRepository.java
@@ -4,6 +4,7 @@ package com.sparta.dtogram.user.repository;
 import com.sparta.dtogram.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -16,4 +17,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByKakaoId(Long kakaoId);
 
     Optional<User> findByNaverId(String naverId);
+    List<User> findByNicknameContainsOrderByNicknameAsc(String nickname);
 }

--- a/src/main/java/com/sparta/dtogram/user/service/UserService.java
+++ b/src/main/java/com/sparta/dtogram/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.sparta.dtogram.user.service;
 
+import com.sparta.dtogram.user.dto.ProfileResponseDto;
 import com.sparta.dtogram.user.dto.SignupRequestDto;
 import com.sparta.dtogram.user.entity.PasswordHistory;
 import com.sparta.dtogram.user.entity.User;
@@ -71,11 +72,13 @@ public class UserService {
                 );
     }
 
-    public List<User> getAllUsers(){
-        return userRepository.findAll();
+    public List<ProfileResponseDto> getAllUsers(){
+        return userRepository.findAll()
+                .stream().map(ProfileResponseDto::new).toList();
     }
 
-    public List<User> getAllUsers(String nickname){
-        return userRepository.findByNicknameContainsOrderByNicknameAsc(nickname); //todo 페이징 작업 추가
+    public List<ProfileResponseDto> getAllUsers(String nickname){
+        return userRepository.findByNicknameContainsOrderByNicknameAsc(nickname)
+                .stream().map(ProfileResponseDto::new).toList(); //todo 페이징 작업 추가?
     }
 }

--- a/src/main/java/com/sparta/dtogram/user/service/UserService.java
+++ b/src/main/java/com/sparta/dtogram/user/service/UserService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -62,5 +63,19 @@ public class UserService {
 
         // 사용했던 비밀번호 목록에 저장
         passwordHistoryRepository.save(new PasswordHistory(requestDto.getPassword(), user));
+    }
+
+    public User getUser(Long id) {
+        return userRepository.findById(id).orElseThrow(()->
+                new NullPointerException("유저 정보를 찾을 수 없습니다.")
+                );
+    }
+
+    public List<User> getAllUsers(){
+        return userRepository.findAll();
+    }
+
+    public List<User> getAllUsers(String nickname){
+        return userRepository.findByNicknameContainsOrderByNicknameAsc(nickname); //todo 페이징 작업 추가
     }
 }


### PR DESCRIPTION
조회 기능
1. 다건조회시 url변경 user -> users (단건 조회의 user/{id}와 user 이 둘이 충돌이 일어남)
2. ProfileResponseDto로 반환하는 형태 -> 이후 변경점이 있을 시 수정 예정.

수정, 삭제 기능
- ADMIN권한 확인 후 수정, 조회 기능 구현
- updateProfile에서 nickname이 null인 경우, null로 처리하지 않도록 변경.

운영자 권한 관련
- ROLE_MANAGER 추가
- admin이 user의 role 변경하는 api 추가



